### PR TITLE
Issue28

### DIFF
--- a/src/Soloplan.WhatsON.CruiseControl/CruiseControlConnector.cs
+++ b/src/Soloplan.WhatsON.CruiseControl/CruiseControlConnector.cs
@@ -18,11 +18,13 @@ namespace Soloplan.WhatsON.CruiseControl
   using Soloplan.WhatsON.CruiseControl.Model;
   using Soloplan.WhatsON.Model;
 
-  [ConnectorType(ConnectorName, Description = "Retrieve the current status of a Cruise Control project.")]
+  [ConnectorType(ConnectorName, ConnectorDisplayName, Description = "Retrieve the current status of a Cruise Control project.")]
   [NotificationConfigurationItem(NotificationsVisbility, typeof(ConnectorNotificationConfiguration), SupportsUnstableNotify = false, Priority = 1600000000)]
   public class CruiseControlConnector : Connector
   {
     public const string ConnectorName = "CruiseControl";
+
+    public const string ConnectorDisplayName = "Cruise Control.Net";
 
     private static readonly Logger log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType?.ToString());
 

--- a/src/Soloplan.WhatsON.GUI/Configuration/View/ConnectorsConfigPage.xaml.cs
+++ b/src/Soloplan.WhatsON.GUI/Configuration/View/ConnectorsConfigPage.xaml.cs
@@ -282,6 +282,7 @@ namespace Soloplan.WhatsON.GUI.Configuration.View
         // TODO move to connector view model/model
         newConnector.SourceConnectorPlugin = (ConnectorPlugin)createEditDialod.uxPluginType.SelectedItem;
         newConnector.Name = createEditDialod.uxEditConnectorName.Text;
+        newConnector.DisplayName = newConnector.SourceConnectorPlugin.DisplayName;
         newConnector.Load(null);
         this.Connectors.Add(newConnector);
         this.CurrentConnector = newConnector;

--- a/src/Soloplan.WhatsON.GUI/Configuration/View/ConnectorsConfigPage.xaml.cs
+++ b/src/Soloplan.WhatsON.GUI/Configuration/View/ConnectorsConfigPage.xaml.cs
@@ -282,7 +282,6 @@ namespace Soloplan.WhatsON.GUI.Configuration.View
         // TODO move to connector view model/model
         newConnector.SourceConnectorPlugin = (ConnectorPlugin)createEditDialod.uxPluginType.SelectedItem;
         newConnector.Name = createEditDialod.uxEditConnectorName.Text;
-        newConnector.DisplayName = newConnector.SourceConnectorPlugin.DisplayName;
         newConnector.Load(null);
         this.Connectors.Add(newConnector);
         this.CurrentConnector = newConnector;

--- a/src/Soloplan.WhatsON.GUI/Configuration/View/CreateEditConnectorDialog.xaml
+++ b/src/Soloplan.WhatsON.GUI/Configuration/View/CreateEditConnectorDialog.xaml
@@ -16,7 +16,7 @@
               Height="28"
               Margin="0,8,0,10"
               Cursor="Hand"
-              DisplayMemberPath="Name"
+              DisplayMemberPath="DisplayName"
               ItemsSource="{Binding Path=ConnectorPlugins, Source={x:Static whatsOn:PluginManager.Instance}}" />
     <TextBox x:Name="uxEditConnectorName"
              Margin="0,8,0,0"

--- a/src/Soloplan.WhatsON.GUI/Configuration/ViewModel/ConnectorViewModel.cs
+++ b/src/Soloplan.WhatsON.GUI/Configuration/ViewModel/ConnectorViewModel.cs
@@ -25,11 +25,6 @@ namespace Soloplan.WhatsON.GUI.Configuration.ViewModel
     private string name;
 
     /// <summary>
-    /// The name of the connector to be displayed.
-    /// </summary>
-    private string displayName;
-
-    /// <summary>
     /// The source connector.
     /// </summary>
     private ConnectorConfiguration sourceConnectorConfiguration;
@@ -89,15 +84,7 @@ namespace Soloplan.WhatsON.GUI.Configuration.ViewModel
       }
     }
 
-    public string DisplayName
-    {
-      get => this.displayName;
-      set
-      {
-        this.displayName = value;
-        this.OnPropertyChanged();
-      }
-    }
+
 
     /// <summary>
     /// Gets the full name of this connector including the category (if set).

--- a/src/Soloplan.WhatsON.GUI/Configuration/ViewModel/ConnectorViewModel.cs
+++ b/src/Soloplan.WhatsON.GUI/Configuration/ViewModel/ConnectorViewModel.cs
@@ -25,6 +25,11 @@ namespace Soloplan.WhatsON.GUI.Configuration.ViewModel
     private string name;
 
     /// <summary>
+    /// The name of the connector to be displayed.
+    /// </summary>
+    private string displayName;
+
+    /// <summary>
     /// The source connector.
     /// </summary>
     private ConnectorConfiguration sourceConnectorConfiguration;
@@ -80,6 +85,16 @@ namespace Soloplan.WhatsON.GUI.Configuration.ViewModel
       set
       {
         this.name = value;
+        this.OnPropertyChanged();
+      }
+    }
+
+    public string DisplayName
+    {
+      get => this.displayName;
+      set
+      {
+        this.displayName = value;
         this.OnPropertyChanged();
       }
     }

--- a/src/Soloplan.WhatsON.GUI/Configuration/Wizard/ConnectionWizardPage.xaml
+++ b/src/Soloplan.WhatsON.GUI/Configuration/Wizard/ConnectionWizardPage.xaml
@@ -27,6 +27,7 @@
                   VerticalAlignment="Center"
                   Orientation="Vertical">
         <ComboBox materialDesign:HintAssist.Hint="Type"
+                  DisplayMemberPath="DisplayName"
                   ItemsSource="{Binding AvailableConnectorTypes}"
                   SelectedItem="{Binding SelectedConnectorType}"
                   Style="{StaticResource MaterialDesignFloatingHintComboBox}" />

--- a/src/Soloplan.WhatsON.GUI/Configuration/Wizard/WizardController.cs
+++ b/src/Soloplan.WhatsON.GUI/Configuration/Wizard/WizardController.cs
@@ -594,7 +594,7 @@ namespace Soloplan.WhatsON.GUI.Configuration.Wizard
       }
       else
       {
-        var plugin = PluginManager.Instance.ConnectorPlugins.FirstOrDefault(x => x.Name.Equals(this.SelectedConnectorType));
+        var plugin = PluginManager.Instance.ConnectorPlugins.FirstOrDefault(x => x.Name.Equals(this.SelectedConnectorType.Name));
         pluginToQueryWithModel = new Tuple<ConnectorPlugin, ProjectViewModelList>(plugin, new ProjectViewModelList { MultiSelectionMode = this.MultiSelectionMode, PlugIn = plugin });
       }
 

--- a/src/Soloplan.WhatsON.GUI/Configuration/Wizard/WizardController.cs
+++ b/src/Soloplan.WhatsON.GUI/Configuration/Wizard/WizardController.cs
@@ -81,7 +81,7 @@ namespace Soloplan.WhatsON.GUI.Configuration.Wizard
     /// </summary>
     private bool isProposedAddressEmpty = true;
 
-    private string selectedConnectorType;
+    private ConnectorPlugin selectedConnectorType;
 
     /// <summary>
     /// The connector view model.
@@ -235,21 +235,22 @@ namespace Soloplan.WhatsON.GUI.Configuration.Wizard
         }
 
         return this.config.ConnectorsConfiguration.Where(x =>
-          x.Type == this.SelectedConnectorType &&
+          x.Type == this.SelectedConnectorType.Name &&
           x.GetConfigurationByKey(Connector.ServerAddress) != null &&
           !string.IsNullOrEmpty(x.GetConfigurationByKey(Connector.ServerAddress).Value)).Select(x => new Uri(x.GetConfigurationByKey(Connector.ServerAddress).Value).AbsoluteUri).Distinct().ToList();
       }
     }
 
-    public List<string> AvailableConnectorTypes
+    public List<ConnectorPlugin> AvailableConnectorTypes
     {
       get
       {
-        return PluginManager.Instance.ConnectorPlugins.Select(x => x.Name).OrderByDescending(x => this.config.ConnectorsConfiguration.Count(y => y.Type == x)).ToList();
+        return PluginManager.Instance.ConnectorPlugins.OrderByDescending(x => this.config.ConnectorsConfiguration.Count(y => y.Type == x.Name)).ToList();
       }
     }
 
-    public string SelectedConnectorType
+
+    public ConnectorPlugin SelectedConnectorType
     {
       get
       {
@@ -546,7 +547,7 @@ namespace Soloplan.WhatsON.GUI.Configuration.Wizard
       this.WizardFrame.Content = this.currentPage;
       if (this.editedConnectorViewModel != null)
       {
-        this.SelectedConnectorType = this.editedConnectorViewModel.SourceConnectorPlugin.Name;
+        this.SelectedConnectorType = this.editedConnectorViewModel.SourceConnectorPlugin;
       }
 
       this.OnPageChanged();
@@ -568,7 +569,7 @@ namespace Soloplan.WhatsON.GUI.Configuration.Wizard
             return false;
           }
 
-          return x.Type == this.SelectedConnectorType
+            return x.Type == this.SelectedConnectorType.Name
           && new Uri(address).AbsoluteUri.Equals(this.ProposedServerAddress)
           && x.GetConfigurationByKey(Connector.ProjectName)?.Value == (!string.IsNullOrWhiteSpace(project.FullName) ? project.FullName : project.Name);
         }).ToList();

--- a/src/Soloplan.WhatsON.Jenkins/JenkinsConnector.cs
+++ b/src/Soloplan.WhatsON.Jenkins/JenkinsConnector.cs
@@ -18,16 +18,18 @@ namespace Soloplan.WhatsON.Jenkins
   using Soloplan.WhatsON.Jenkins.Model;
   using Soloplan.WhatsON.Model;
 
-  [ConnectorType(ConnectorName, Description = "Retrieve the current status of a Jenkins project.")]
+  [ConnectorType(ConnectorName, ConnectorDisplayName, Description = "Retrieve the current status of a Jenkins project.")]
   [ConfigurationItem(RedirectPlugin, typeof(bool), Priority = 400)] // defines use of Display URL API Plugin https://wiki.jenkins.io/display/JENKINS/Display+URL+API+Plugin
   [NotificationConfigurationItem(NotificationsVisbility, typeof(ConnectorNotificationConfiguration), Priority = 1600000000)]
   public class JenkinsConnector : Connector
   {
     public const string ConnectorName = "Jenkins";
 
-    /// <summary>
-    /// The redirect plugin tag.
-    /// </summary>
+    public const string ConnectorDisplayName = "Jenkins";
+
+        /// <summary>
+        /// The redirect plugin tag.
+        /// </summary>
     public const string RedirectPlugin = "RedirectPlugin";
 
     private const long TicksInMillisecond = 10000;

--- a/src/Soloplan.WhatsON/Composition/ConnectorPlugin.cs
+++ b/src/Soloplan.WhatsON/Composition/ConnectorPlugin.cs
@@ -27,12 +27,15 @@ namespace Soloplan.WhatsON.Composition
       }
 
       this.Name = connectorTypeAttribute.Name;
+      this.DisplayName = connectorTypeAttribute.DisplayName;
       this.Description = connectorTypeAttribute.Description;
     }
 
     public Type ConnectorType { get; }
 
     public string Name { get; }
+
+    public string DisplayName { get; }
 
     public string Description { get; }
 

--- a/src/Soloplan.WhatsON/Composition/ConnectorTypeAttribute.cs
+++ b/src/Soloplan.WhatsON/Composition/ConnectorTypeAttribute.cs
@@ -10,10 +10,6 @@ namespace Soloplan.WhatsON.Composition
   [AttributeUsage(AttributeTargets.Class)]
   public class ConnectorTypeAttribute : Attribute
   {
-    public ConnectorTypeAttribute() 
-    {
-
-    }
     public ConnectorTypeAttribute(string name)
     {
       this.Name = name;

--- a/src/Soloplan.WhatsON/Composition/ConnectorTypeAttribute.cs
+++ b/src/Soloplan.WhatsON/Composition/ConnectorTypeAttribute.cs
@@ -10,12 +10,25 @@ namespace Soloplan.WhatsON.Composition
   [AttributeUsage(AttributeTargets.Class)]
   public class ConnectorTypeAttribute : Attribute
   {
+    public ConnectorTypeAttribute() 
+    {
+
+    }
     public ConnectorTypeAttribute(string name)
     {
       this.Name = name;
     }
 
+
+    public ConnectorTypeAttribute(string name, string displayName)
+    {
+      this.Name = name;
+      this.DisplayName = displayName;
+    }
+
     public string Name { get; }
+
+    public string DisplayName { get; }
 
     public string Description { get; set; }
   }


### PR DESCRIPTION
Added display properties for plugin names that don't interfere with type names. Changes made in configuration pages and in the wizard popup. As requested in issue #28  CruiseControl is renamed to CruiseControl.Net