### PR TITLE
Issue45

### DIFF
--- a/src/Soloplan.WhatsON.GUI/Configuration/View/CreateEditConnectorDialog.xaml.cs
+++ b/src/Soloplan.WhatsON.GUI/Configuration/View/CreateEditConnectorDialog.xaml.cs
@@ -44,10 +44,7 @@ namespace Soloplan.WhatsON.GUI.Configuration.View
     /// <param name="e">The <see cref="RoutedEventArgs"/> instance containing the event data.</param>
     private void OkButtonClick(object sender, RoutedEventArgs e)
     {
-      foreach (var be in BindingOperations.GetSourceUpdatingBindings(this))
-      {
-        //be.UpdateSource();
-      }
+
     }
 
     /// <summary>

--- a/src/Soloplan.WhatsON.GUI/Configuration/View/CreateEditConnectorDialog.xaml.cs
+++ b/src/Soloplan.WhatsON.GUI/Configuration/View/CreateEditConnectorDialog.xaml.cs
@@ -46,7 +46,7 @@ namespace Soloplan.WhatsON.GUI.Configuration.View
     {
       foreach (var be in BindingOperations.GetSourceUpdatingBindings(this))
       {
-        be.UpdateSource();
+        //be.UpdateSource();
       }
     }
 


### PR DESCRIPTION
Binding the new project configuration to existing project that was displayed caused an unstable behaviour. Sometimes it renamed already exsiting projects to the new given name as described in issue #45. Removing those 4 lines fixed the problem.