### PR TITLE
"Open website" uses wrong URL for CruiseControl projects && Adding CC.NET build job doesn't work properly

### DIFF
--- a/src/Soloplan.WhatsON.CruiseControl.GUI/CruiseControlProjectDataTemplate.xaml
+++ b/src/Soloplan.WhatsON.CruiseControl.GUI/CruiseControlProjectDataTemplate.xaml
@@ -15,22 +15,23 @@
   </ToolTip>
 
   <DataTemplate DataType="{x:Type local:CruiseControlProjectViewModel}">
-    <DockPanel Width="Auto" ContextMenu="{DynamicResource BuildServerProjectContextMenu}">
-      <buildServer:BuildInformationIconControl DataContext="{Binding CurrentStatus}"
+        <DockPanel Width="Auto" ContextMenu="{DynamicResource BuildServerProjectContextMenu}">
+            <buildServer:BuildInformationIconControl DataContext="{Binding CurrentStatus}"
                                                DockPanel.Dock="Left"
                                                ToolTip="{StaticResource CruiseControlBuildInfoToolTip}" />
-      <buildServer:BuildNumberControl Margin="5,0,0,0"
+            <buildServer:BuildNumberControl Margin="5,0,0,0"
                                       VerticalAlignment="Center"
                                       BuildNumber="{Binding DataContext.CurrentStatus.BuildNumber, RelativeSource={RelativeSource AncestorType=DockPanel}}" />
-      <TextBlock MinWidth="150"
+            <TextBlock MinWidth="150"
                  MaxWidth="250"
                  Margin="5,0,0,0"
                  FontSize="{Binding DataContext.FontSize, Mode=OneWay, RelativeSource={RelativeSource AncestorType=connectorTreeView:ConnectorsTreeView}}"
                  FontWeight="Normal"
                  Text="{Binding Name}"
-                 TextTrimming="CharacterEllipsis" />
-      <buildServer:HistoryBuildList DataContext="{Binding ConnectorSnapshots, Mode=OneWay}" DockPanel.Dock="Right" />
-      <TextBlock Margin="5,0,10,0"
+                 TextTrimming="CharacterEllipsis">
+            </TextBlock>
+            <buildServer:HistoryBuildList DataContext="{Binding ConnectorSnapshots, Mode=OneWay}" DockPanel.Dock="Right" />
+            <TextBlock Margin="5,0,10,0"
                  HorizontalAlignment="Right"
                  VerticalAlignment="Center"
                  DockPanel.Dock="Right"
@@ -38,6 +39,9 @@
                  FontWeight="Normal"
                  Text="{Binding CurrentStatus.FinishTime, Converter={StaticResource TimeToApproximateTimeConverter}}"
                  Visibility="{Binding CurrentStatus.FinishTime, Converter={StaticResource NullOrDefaultVisibilityConverter}}" />
-    </DockPanel>
-  </DataTemplate>
+            <DockPanel.ToolTip>
+                <TextBlock Text="{Binding Description}"></TextBlock>
+            </DockPanel.ToolTip>
+        </DockPanel>
+    </DataTemplate>
 </ResourceDictionary>

--- a/src/Soloplan.WhatsON.CruiseControl.GUI/CruiseControlProjectViewModel.cs
+++ b/src/Soloplan.WhatsON.CruiseControl.GUI/CruiseControlProjectViewModel.cs
@@ -16,7 +16,7 @@ namespace Soloplan.WhatsON.CruiseControl.GUI
     public CruiseControlProjectViewModel(CruiseControlConnector connector)
       : base(connector)
     {
-      this.Url = CruiseControlServer.UrlHelper.GetReportUrl(connector.Address);
+      this.Url = CruiseControlServer.UrlHelper.GetReportUrl(connector.directAddress, connector.Project);
     }
 
     protected override BuildStatusViewModel GetStatusViewModel()

--- a/src/Soloplan.WhatsON.CruiseControl.GUI/CruiseControlProjectViewModel.cs
+++ b/src/Soloplan.WhatsON.CruiseControl.GUI/CruiseControlProjectViewModel.cs
@@ -16,7 +16,7 @@ namespace Soloplan.WhatsON.CruiseControl.GUI
     public CruiseControlProjectViewModel(CruiseControlConnector connector)
       : base(connector)
     {
-      this.Url = CruiseControlServer.UrlHelper.GetReportUrl(connector.Address, connector.Project);
+      this.Url = CruiseControlServer.UrlHelper.GetReportUrl(connector.Address);
     }
 
     protected override BuildStatusViewModel GetStatusViewModel()

--- a/src/Soloplan.WhatsON.CruiseControl/CruiseControlConnector.cs
+++ b/src/Soloplan.WhatsON.CruiseControl/CruiseControlConnector.cs
@@ -37,7 +37,7 @@ namespace Soloplan.WhatsON.CruiseControl
 
     protected override async Task<Status> GetCurrentStatus(CancellationToken cancellationToken)
     {
-      var server = CruiseControlManager.GetServer(this.Address);
+      var server = CruiseControlManager.GetServer(this.directAddress);
       var projectData = await server.GetProjectStatus(cancellationToken, this.Project, 5);
       if (projectData == null)
       {
@@ -50,7 +50,7 @@ namespace Soloplan.WhatsON.CruiseControl
 
     protected override async Task<List<Status>> GetHistory(CancellationToken cancellationToken)
     {
-      var server = CruiseControlManager.GetServer(this.Address);
+      var server = CruiseControlManager.GetServer(this.directAddress);
       var history = new List<Status>();
 
       var builds = await server.GetBuilds(this.Project);

--- a/src/Soloplan.WhatsON.CruiseControl/CruiseControlManager.cs
+++ b/src/Soloplan.WhatsON.CruiseControl/CruiseControlManager.cs
@@ -25,7 +25,10 @@ namespace Soloplan.WhatsON.CruiseControl
       server = new CruiseControlServer(uri.AbsoluteUri);
       if (addToCache)
       {
-        servers[uri] = server;
+        if(server!=null)
+        {
+          servers[uri] = server;
+        }
       }
 
       return server;

--- a/src/Soloplan.WhatsON.CruiseControl/CruiseControlPlugin.cs
+++ b/src/Soloplan.WhatsON.CruiseControl/CruiseControlPlugin.cs
@@ -41,7 +41,7 @@ namespace Soloplan.WhatsON.CruiseControl
       var serverProjects = new List<Project>();
       foreach (var project in allProjects.CruiseControlProject)
       {
-        var serverProjectTreeItem = new Project(project.WebUrl, project.Name);
+        var serverProjectTreeItem = new Project(address, project.Name, address + "server/" + project.ServerName + "/project/" + project.Name + "/ViewProjectReport.aspx"); ;
         if (string.IsNullOrWhiteSpace(project.ServerName))
         {
           result.Add(serverProjectTreeItem);
@@ -51,7 +51,7 @@ namespace Soloplan.WhatsON.CruiseControl
           var serverProject = serverProjects.FirstOrDefault(s => s.Name == project.ServerName);
           if (serverProject == null)
           {
-            serverProject = new Project(null, project.ServerName);
+            serverProject = new Project(null, project.ServerName, project.Name, address + "server/" + project.ServerName + "/project/" + project.Name);
             serverProjects.Add(serverProject);
             result.Add(serverProject);
           }
@@ -74,6 +74,7 @@ namespace Soloplan.WhatsON.CruiseControl
     {
       configurationItemsSupport.GetConfigurationByKey(Connector.ProjectName).Value = project.Name;
       configurationItemsSupport.GetConfigurationByKey(Connector.ServerAddress).Value = project.Address;
+      configurationItemsSupport.GetConfigurationByKey(Connector.DirectAddress).Value = project.DirectAddress;
     }
   }
 }

--- a/src/Soloplan.WhatsON.CruiseControl/CruiseControlPlugin.cs
+++ b/src/Soloplan.WhatsON.CruiseControl/CruiseControlPlugin.cs
@@ -41,7 +41,7 @@ namespace Soloplan.WhatsON.CruiseControl
       var serverProjects = new List<Project>();
       foreach (var project in allProjects.CruiseControlProject)
       {
-        var serverProjectTreeItem = new Project(address, project.Name);
+        var serverProjectTreeItem = new Project(project.WebUrl, project.Name);
         if (string.IsNullOrWhiteSpace(project.ServerName))
         {
           result.Add(serverProjectTreeItem);
@@ -70,10 +70,10 @@ namespace Soloplan.WhatsON.CruiseControl
     /// <param name="project">The server project.</param>
     /// <param name="configurationItemsSupport">The configuration items provider.</param>
     /// <param name="serverAddress">The server address.</param>
-    public override void Configure(Project project, IConfigurationItemProvider configurationItemsSupport, string serverAddress)
+    public override void Configure(Project project, IConfigurationItemProvider configurationItemsSupport, string serverAddress=null)
     {
       configurationItemsSupport.GetConfigurationByKey(Connector.ProjectName).Value = project.Name;
-      configurationItemsSupport.GetConfigurationByKey(Connector.ServerAddress).Value = serverAddress;
+      configurationItemsSupport.GetConfigurationByKey(Connector.ServerAddress).Value = project.Address;
     }
   }
 }

--- a/src/Soloplan.WhatsON.CruiseControl/CruiseControlPlugin.cs
+++ b/src/Soloplan.WhatsON.CruiseControl/CruiseControlPlugin.cs
@@ -51,7 +51,7 @@ namespace Soloplan.WhatsON.CruiseControl
           var serverProject = serverProjects.FirstOrDefault(s => s.Name == project.ServerName);
           if (serverProject == null)
           {
-            serverProject = new Project(null, project.ServerName, project.Name, address + "server/" + project.ServerName + "/project/" + project.Name);
+            serverProject = new Project(null, project.ServerName, address+"server/"+project.ServerName+"/viewServerReport.aspx", project.Name, address + "server/" + project.ServerName + "/project/" + project.Name);
             serverProjects.Add(serverProject);
             result.Add(serverProject);
           }

--- a/src/Soloplan.WhatsON.CruiseControl/CruiseControlServer.cs
+++ b/src/Soloplan.WhatsON.CruiseControl/CruiseControlServer.cs
@@ -124,9 +124,9 @@ namespace Soloplan.WhatsON.CruiseControl
 
     public static class UrlHelper
     {
-      public static string GetReportUrl(string baseUrl, string project)
+      public static string GetReportUrl(string baseUrl, string project=null)
       {
-        return $"{SanitizeBaseUri(baseUrl)}/project/{Uri.EscapeDataString(project)}/ViewProjectReport.aspx";
+        return $"{SanitizeBaseUri(baseUrl)}"+(project!=null?$"/project/{Uri.EscapeDataString(project)}/ViewProjectReport.aspx":string.Empty);
       }
 
       public static string GetXmlReportUrl(string baseUrl)

--- a/src/Soloplan.WhatsON.GUI/Configuration/View/ConnectorsConfigPage.xaml.cs
+++ b/src/Soloplan.WhatsON.GUI/Configuration/View/ConnectorsConfigPage.xaml.cs
@@ -316,6 +316,7 @@ namespace Soloplan.WhatsON.GUI.Configuration.View
             newConnector.Load(null);
             newConnector.GetConfigurationByKey(Connector.ProjectName).Value = selectedProject.FullName;
             newConnector.GetConfigurationByKey(Connector.ServerAddress).Value = !string.IsNullOrWhiteSpace(wizardController.ProposedServerAddress) ? new Uri(wizardController.ProposedServerAddress).AbsoluteUri : string.Empty;
+            newConnector.GetConfigurationByKey(Connector.DirectAddress).Value = selectedProject.DirectAddress;
             this.Connectors.Add(newConnector);
             this.CurrentConnector = newConnector;
           }

--- a/src/Soloplan.WhatsON.GUI/Configuration/Wizard/ProjectViewModel.cs
+++ b/src/Soloplan.WhatsON.GUI/Configuration/Wizard/ProjectViewModel.cs
@@ -16,7 +16,7 @@ namespace Soloplan.WhatsON.GUI.Configuration.Wizard
   /// <summary>
   /// The view model for the selectable projects on the wizard.
   /// </summary>
-  /// <seealso cref="System.ComponentModel.INotifyPropertyChanged" />
+  /// <seealso cref="System.ComponentModel.INotifyPropertyChanged"/>
   public class ProjectViewModel : INotifyPropertyChanged
   {
     /// <summary>

--- a/src/Soloplan.WhatsON.GUI/Configuration/Wizard/ProjectViewModel.cs
+++ b/src/Soloplan.WhatsON.GUI/Configuration/Wizard/ProjectViewModel.cs
@@ -78,6 +78,8 @@ namespace Soloplan.WhatsON.GUI.Configuration.Wizard
 
     public string Description { get; set; }
 
+    public string DirectAddress { get; set; }
+
     /// <summary>
     /// Gets or sets a value indicating whether this project is visible.
     /// </summary>

--- a/src/Soloplan.WhatsON.GUI/Configuration/Wizard/ProjectsTreeView.xaml
+++ b/src/Soloplan.WhatsON.GUI/Configuration/Wizard/ProjectsTreeView.xaml
@@ -27,7 +27,7 @@
                        Focusable="False"
                        Text="{Binding Name}" />
             <TextBlock Margin="5,0,0,0">
-              <Hyperlink NavigateUri="{Binding Address}"
+              <Hyperlink NavigateUri="{Binding DirectAddress}"
                          RequestNavigate="HyperlinkRequestNavigate"
                          Style="{StaticResource MaterialDesignHeadline4Hyperlink}">
                 <TextBlock>

--- a/src/Soloplan.WhatsON.GUI/Configuration/Wizard/WizardController.cs
+++ b/src/Soloplan.WhatsON.GUI/Configuration/Wizard/WizardController.cs
@@ -500,7 +500,7 @@ namespace Soloplan.WhatsON.GUI.Configuration.Wizard
       {
         var newConnector = new ConnectorViewModel();
         newConnector.SourceConnectorPlugin = selectedProject.Plugin;
-        newConnector.Name = this.SelectedGroupingSetting.Id == WizardWindow.AddProjectPathToProjectName ? selectedProject.FullName : selectedProject.Name;
+        newConnector.Name = selectedProject.Name;
         newConnector.Load(null);
         if (this.SelectedGroupingSetting.Id == WizardWindow.AssignGroupsForAddedProjects)
         {
@@ -514,7 +514,7 @@ namespace Soloplan.WhatsON.GUI.Configuration.Wizard
 
         configurationViewModel.Connectors.Add(newConnector);
 
-        selectedProject.Plugin.Configure(selectedProject, newConnector, this.ProposedServerAddress);
+        selectedProject.Plugin.Configure(selectedProject, newConnector, proposedServerAddress);
       }
 
       if (configurationViewModel.ConfigurationIsModified)

--- a/src/Soloplan.WhatsON.GUI/Configuration/Wizard/WizardController.cs
+++ b/src/Soloplan.WhatsON.GUI/Configuration/Wizard/WizardController.cs
@@ -380,7 +380,7 @@ namespace Soloplan.WhatsON.GUI.Configuration.Wizard
         return null;
       }
 
-      var newParent = new Project(viewModel.Parent.Address, viewModel.Parent.Name, viewModel.Parent.FullName, viewModel.Parent.Description, this.Projects.PlugIn, this.CreateParentProjectStructure(viewModel.Parent));
+      var newParent = new Project(viewModel.Parent.Address, viewModel.Parent.Name, viewModel.Parent.DirectAddress, viewModel.Parent.FullName, viewModel.Parent.Description, this.Projects.PlugIn, this.CreateParentProjectStructure(viewModel.Parent));
       return newParent;
     }
 
@@ -399,7 +399,7 @@ namespace Soloplan.WhatsON.GUI.Configuration.Wizard
       var checkedProjects = this.Projects.GetChecked();
       foreach (var checkedProject in checkedProjects.Where(p => p.Projects.Count == 0))
       {
-        var newProject = new Project(checkedProject.Address, checkedProject.Name, checkedProject.FullName, checkedProject.Description, this.Projects.PlugIn, this.CreateParentProjectStructure(checkedProject));
+        var newProject = new Project(checkedProject.Address, checkedProject.Name, checkedProject.DirectAddress, checkedProject.FullName, checkedProject.Description, this.Projects.PlugIn, this.CreateParentProjectStructure(checkedProject));
         serverProjects.Add(newProject);
       }
 
@@ -560,6 +560,7 @@ namespace Soloplan.WhatsON.GUI.Configuration.Wizard
         var newProject = projectViewModel.AddProject(project);
         newProject.Parent = projectViewModel;
         newProject.Address = project.Address;
+        newProject.DirectAddress = project.DirectAddress;
 
         var alreadyExists = this.config.ConnectorsConfiguration.Where(x =>
         {
@@ -641,6 +642,7 @@ namespace Soloplan.WhatsON.GUI.Configuration.Wizard
       {
         var newProject = listQueryingPlugin.Item2.AddProject(serverProject);
         newProject.Address = serverProject.Address;
+        newProject.DirectAddress = serverProject.DirectAddress;
         this.ProcessServerSubProjects(serverProject.Children, newProject);
       }
     }

--- a/src/Soloplan.WhatsON.Jenkins.GUI/JenkinsProjectDataTemplate.xaml
+++ b/src/Soloplan.WhatsON.Jenkins.GUI/JenkinsProjectDataTemplate.xaml
@@ -78,6 +78,9 @@
       <DockPanel>
         <TextBlock />
       </DockPanel>
-    </DockPanel>
+      <DockPanel.ToolTip>
+        <TextBlock Text="{Binding Description}"></TextBlock>
+      </DockPanel.ToolTip>
+        </DockPanel>
   </DataTemplate>
 </ResourceDictionary>

--- a/src/Soloplan.WhatsON.Jenkins/JenkinsPlugin.cs
+++ b/src/Soloplan.WhatsON.Jenkins/JenkinsPlugin.cs
@@ -113,7 +113,7 @@ namespace Soloplan.WhatsON.Jenkins
     /// <returns>The newly  created server projects tree item.</returns>
     private Project AddProject(IList<Project> parentList, JenkinsJob jenkinsJobsItem)
     {
-      var newServerProject = new Project(jenkinsJobsItem.Url, jenkinsJobsItem.DisplayName ?? jenkinsJobsItem.Name, jenkinsJobsItem.FullName, jenkinsJobsItem.Description);
+      var newServerProject = new Project(jenkinsJobsItem.Url, jenkinsJobsItem.DisplayName ?? jenkinsJobsItem.Name, jenkinsJobsItem.Url, jenkinsJobsItem.FullName, jenkinsJobsItem.Description);
       parentList.Add(newServerProject);
       return newServerProject;
     }

--- a/src/Soloplan.WhatsON/Composition/ConnectorPlugin.cs
+++ b/src/Soloplan.WhatsON/Composition/ConnectorPlugin.cs
@@ -47,7 +47,7 @@ namespace Soloplan.WhatsON.Composition
     /// <param name="project">The server project.</param>
     /// <param name="configurationItemsSupport">The configuration items provider.</param>
     /// <param name="serverAddress">The server address.</param>
-    public abstract void Configure(Project project, IConfigurationItemProvider configurationItemsSupport, string serverAddress);
+    public abstract void Configure(Project project, IConfigurationItemProvider configurationItemsSupport, string serverAddress=null);
 
     /// <summary>
     /// Gets the projects.

--- a/src/Soloplan.WhatsON/Model/Connector.cs
+++ b/src/Soloplan.WhatsON/Model/Connector.cs
@@ -22,6 +22,7 @@ namespace Soloplan.WhatsON.Model
   [ConfigurationItem(Category, typeof(string), Priority = 1000000000)]
   [ConfigurationItem(ServerAddress, typeof(string), Optional = false, Priority = 100)]
   [ConfigurationItem(ProjectName, typeof(string), Optional = false, Priority = 300)]
+  [ConfigurationItem(DirectAddress, typeof(string),Optional = false, Priority = 0)]
   public abstract class Connector
   {
     /// <summary>
@@ -37,6 +38,8 @@ namespace Soloplan.WhatsON.Model
     public const string ServerAddress = "Address";
 
     public const string ProjectName = "ProjectName";
+
+    public const string DirectAddress = "DirectAddress";
 
     /// <summary>
     /// Default value for max nubmer of snapshots.
@@ -86,6 +89,12 @@ namespace Soloplan.WhatsON.Model
     {
       get => this.Configuration.GetConfigurationByKey(ProjectName).Value;
       set => this.Configuration.GetConfigurationByKey(ProjectName).Value = value;
+    }
+
+    public string directAddress
+    {
+      get => this.Configuration.GetConfigurationByKey(DirectAddress).Value;
+      set => this.Configuration.GetConfigurationByKey(DirectAddress).Value = value;
     }
 
     /// <summary>

--- a/src/Soloplan.WhatsON/Model/Project.cs
+++ b/src/Soloplan.WhatsON/Model/Project.cs
@@ -24,7 +24,7 @@ namespace Soloplan.WhatsON.Model
     /// <param name="description">The description.</param>
     /// <param name="projectPlugIn">The project plug in.</param>
     /// <param name="parent">The parent.</param>
-    public Project(string address, string name, string fullName = null, string description = null, ConnectorPlugin projectPlugIn = null, Project parent = null)
+    public Project(string address, string name, string directAddress, string fullName = null, string description = null, ConnectorPlugin projectPlugIn = null, Project parent = null)
     {
       this.Address = address;
       this.Name = name;
@@ -32,6 +32,7 @@ namespace Soloplan.WhatsON.Model
       this.Description = description;
       this.Plugin = projectPlugIn;
       this.Parent = parent;
+      this.DirectAddress = directAddress;
     }
 
     /// <summary>
@@ -42,6 +43,8 @@ namespace Soloplan.WhatsON.Model
     public string FullName { get; set; }
 
     public string Description { get; set; }
+
+    public string DirectAddress { get; set; }
 
     /// <summary>
     /// Gets or sets the address of the project.


### PR DESCRIPTION
both issues 33 and 40 are fixed. There are correct hyperlinks to the cc jobs and categories. It required to add a new directaddress prop that allows cc jobs to pull correct data from direct links. CCjobs before did not show any retrieved data.