### PR TITLE
Highlight obsolete jobs

### DIFF
--- a/src/Soloplan.WhatsON.CruiseControl.GUI/CruiseControlProjectDataTemplate.xaml
+++ b/src/Soloplan.WhatsON.CruiseControl.GUI/CruiseControlProjectDataTemplate.xaml
@@ -13,6 +13,7 @@
   <StackPanel>
     <local:CCProgressBarTooltipControl DataContext="{Binding}" />
     <buildServer:CulpritsControl Caption="Changes by:" CulpritsProp="{Binding DataContext.Culprits, RelativeSource={RelativeSource AncestorType=StackPanel}}" />
+    <TextBlock Text="{Binding ErrorMessage, Mode=OneWay}" Visibility="{Binding State , Converter={StaticResource StatusTotooltipVisibilityConverter}}" />
   </StackPanel>
   </ToolTip>
 

--- a/src/Soloplan.WhatsON.CruiseControl.GUI/CruiseControlProjectDataTemplate.xaml
+++ b/src/Soloplan.WhatsON.CruiseControl.GUI/CruiseControlProjectDataTemplate.xaml
@@ -8,6 +8,7 @@
   <converters:TimeToApproximateTimeConverter x:Key="TimeToApproximateTimeConverter" />
   <converters:NullOrDefaultToVisibilityConverter x:Key="NullOrDefaultVisibilityConverter" />
   <converters:MainStatusToVisibilityConverter x:Key="MainStatusToVisibilityConverter" />
+  <converters:StatusTotooltipVisibilityConverter x:Key="StatusTotooltipVisibilityConverter"/>
   <ToolTip x:Key="CruiseControlBuildInfoToolTip" Visibility="{Binding Path=. , Converter={StaticResource MainStatusToVisibilityConverter}}">
   <StackPanel>
     <local:CCProgressBarTooltipControl DataContext="{Binding}" />
@@ -19,6 +20,7 @@
         <StackPanel DataContext="{Binding CurrentStatus}">
             <local:CCProgressBarTooltipControl DataContext="{Binding}" />
             <buildServer:CulpritsControl Caption="Changes by:" CulpritsProp="{Binding DataContext.Culprits, RelativeSource={RelativeSource AncestorType=StackPanel}}" />
+            <TextBlock Text="{Binding ErrorMessage, Mode=OneWay}" Visibility="{Binding State , Converter={StaticResource StatusTotooltipVisibilityConverter}}" />
         </StackPanel>
     </ToolTip>
 

--- a/src/Soloplan.WhatsON.CruiseControl.GUI/CruiseControlProjectViewModel.cs
+++ b/src/Soloplan.WhatsON.CruiseControl.GUI/CruiseControlProjectViewModel.cs
@@ -9,6 +9,8 @@ namespace Soloplan.WhatsON.CruiseControl.GUI
 {
   using System;
   using System.Windows.Navigation;
+  using Microsoft.Win32;
+  using Soloplan.WhatsON.Configuration;
   using Soloplan.WhatsON.GUI.Common.BuildServer;
   using Soloplan.WhatsON.GUI.Common.ConnectorTreeView;
   using Soloplan.WhatsON.Model;
@@ -36,8 +38,14 @@ namespace Soloplan.WhatsON.CruiseControl.GUI
       {
         return (status.Culprits.Count == 0 && status.State != ObservationState.Running) ? false : true;
       }
-      
+
       return true;
+    }
+
+    public override void ApplyConfiguration(ConnectorConfiguration configuration)
+    {
+      base.ApplyConfiguration(configuration);
+      this.Url = CruiseControlServer.UrlHelper.GetReportUrl(this.Connector.directAddress, this.Connector.Project);
     }
   }
 }

--- a/src/Soloplan.WhatsON.CruiseControl.GUI/CruiseControlProjectViewModel.cs
+++ b/src/Soloplan.WhatsON.CruiseControl.GUI/CruiseControlProjectViewModel.cs
@@ -20,7 +20,7 @@ namespace Soloplan.WhatsON.CruiseControl.GUI
     public CruiseControlProjectViewModel(CruiseControlConnector connector)
       : base(connector)
     {
-      this.Url = CruiseControlServer.UrlHelper.GetReportUrl(connector.directAddress, connector.Project);
+      this.Url = CruiseControlServer.UrlHelper.GetReportUrl(connector.directAddress, Connector?.Project);
     }
 
     protected override BuildStatusViewModel GetStatusViewModel()
@@ -36,7 +36,7 @@ namespace Soloplan.WhatsON.CruiseControl.GUI
     {
       if (this.CurrentStatus is CruiseControlStatusViewModel status)
       {
-        return (status.Culprits.Count == 0 && status.State != ObservationState.Running) ? false : true;
+        return (status.Culprits.Count == 0 && status.State != ObservationState.Running && status.State != ObservationState.Unknown) ? false : true;
       }
 
       return true;
@@ -45,7 +45,7 @@ namespace Soloplan.WhatsON.CruiseControl.GUI
     public override void ApplyConfiguration(ConnectorConfiguration configuration)
     {
       base.ApplyConfiguration(configuration);
-      this.Url = CruiseControlServer.UrlHelper.GetReportUrl(this.Connector.directAddress, this.Connector.Project);
+      this.Url = CruiseControlServer.UrlHelper.GetReportUrl(this.Connector.directAddress, this.Connector?.Project);
     }
   }
 }

--- a/src/Soloplan.WhatsON.CruiseControl/CruiseControlConnector.cs
+++ b/src/Soloplan.WhatsON.CruiseControl/CruiseControlConnector.cs
@@ -35,6 +35,33 @@ namespace Soloplan.WhatsON.CruiseControl
     {
     }
 
+    /// <summary>
+    /// Checks correctness of self server URL.
+    /// </summary>
+    /// <returns>true when fine, false when url is broken.</returns>
+    public override async Task<bool> CheckServerURL()
+    {
+      return false;
+    }
+
+    /// <summary>
+    /// Checks correctness of self project URL.
+    /// </summary>
+    /// <returns>true when fine, false when url is broken.</returns>
+    public override async Task<bool> CheckProjectURL()
+    {
+      return false;
+    }
+
+    /// <summary>
+    /// Checks if there are any builds available.
+    /// </summary>
+    /// <returns>True when there are any builds, false when there are no builds.</returns>
+    public override bool HasBuilds()
+    {
+      return false;
+    }
+
     protected override async Task<Status> GetCurrentStatus(CancellationToken cancellationToken)
     {
       var server = CruiseControlManager.GetServer(this.directAddress);

--- a/src/Soloplan.WhatsON.CruiseControl/CruiseControlConnector.cs
+++ b/src/Soloplan.WhatsON.CruiseControl/CruiseControlConnector.cs
@@ -59,7 +59,28 @@ namespace Soloplan.WhatsON.CruiseControl
       var projectData = await server.GetProjectStatus(cancellationToken, this.Project, 5);
       if (projectData == null)
       {
-        return null;
+        if (await this.CheckServerURL() == false)
+        {
+          var status = new Status();
+          status.ErrorMessage = "Server not available";
+          status.InvalidBuild = true;
+          return status;
+        }
+        else if (await this.CheckProjectURL() == false)
+        {
+          var status = new Status();
+          status.ErrorMessage = "Project not available";
+          status.InvalidBuild = true;
+          return status;
+        }
+      }
+
+      if (projectData.LastBuildLabel == null)
+      {
+        var status = new Status();
+        status.ErrorMessage = "No builds yet";
+        status.InvalidBuild = true;
+        return status;
       }
 
       log.Trace("Retrieved status for cruise control project {project}: {@projectData}", this.Project, projectData);

--- a/src/Soloplan.WhatsON.CruiseControl/CruiseControlConnector.cs
+++ b/src/Soloplan.WhatsON.CruiseControl/CruiseControlConnector.cs
@@ -53,15 +53,6 @@ namespace Soloplan.WhatsON.CruiseControl
       return false;
     }
 
-    /// <summary>
-    /// Checks if there are any builds available.
-    /// </summary>
-    /// <returns>True when there are any builds, false when there are no builds.</returns>
-    public override bool HasBuilds()
-    {
-      return false;
-    }
-
     protected override async Task<Status> GetCurrentStatus(CancellationToken cancellationToken)
     {
       var server = CruiseControlManager.GetServer(this.directAddress);

--- a/src/Soloplan.WhatsON.GUI.Common/BuildServer/BuildStatusViewModel.cs
+++ b/src/Soloplan.WhatsON.GUI.Common/BuildServer/BuildStatusViewModel.cs
@@ -306,6 +306,7 @@ namespace Soloplan.WhatsON.GUI.Common.BuildServer
       this.EstimatedDuration = newStatus.EstimatedDuration;
       this.Label = newStatus.Label;
       this.Url = newStatus.Url;
+      this.ErrorMessage = newStatus.ErrorMessage;
 
       this.UpdateCalculatedFields();
     }

--- a/src/Soloplan.WhatsON.GUI.Common/ConnectorTreeView/ConnectorViewModel.cs
+++ b/src/Soloplan.WhatsON.GUI.Common/ConnectorTreeView/ConnectorViewModel.cs
@@ -7,7 +7,6 @@ namespace Soloplan.WhatsON.GUI.Common.ConnectorTreeView
 {
   using System;
   using System.Collections.ObjectModel;
-  using System.Threading.Tasks;
   using System.Windows;
   using System.Windows.Controls;
   using System.Windows.Input;

--- a/src/Soloplan.WhatsON.GUI.Common/ConnectorTreeView/ConnectorViewModel.cs
+++ b/src/Soloplan.WhatsON.GUI.Common/ConnectorTreeView/ConnectorViewModel.cs
@@ -175,46 +175,9 @@ namespace Soloplan.WhatsON.GUI.Common.ConnectorTreeView
           }
         }
 
-        if (changedConnector.CurrentStatus == null)
-        {
-          Task.Run(new Action(() => CheckForErrors(this.CurrentStatus,changedConnector)));
-        }
-
         this.Description = changedConnector.Description;
         this.CurrentStatus.Update(changedConnector.CurrentStatus);
       }));
-    }
-
-    public async Task CheckForErrors(BuildStatusViewModel build, Connector connector)
-    {
-      Status status = connector.CurrentStatus ?? new Status();
-
-      bool anyChanges = false;
-      if (connector.HasBuilds() == false)
-      {
-        anyChanges = true;
-        status.Details = "No builds yet";
-        status.State = ObservationState.Unknown;
-      }
-
-      if (await connector.CheckServerURL() == false)
-      {
-        anyChanges = true;
-        status.Details = "Project not available";
-        status.State = ObservationState.Unknown;
-      }
-      else if (await connector.CheckProjectURL() == false)
-      {
-        anyChanges = true;
-        status.Details = "Server not available";
-        status.State = ObservationState.Unknown;
-      }
-
-      if (anyChanges == true)
-      {
-        build.Update(status);
-      }
-      return;
     }
 
     /// <summary>

--- a/src/Soloplan.WhatsON.GUI.Common/ConnectorTreeView/ConnectorViewModel.cs
+++ b/src/Soloplan.WhatsON.GUI.Common/ConnectorTreeView/ConnectorViewModel.cs
@@ -7,6 +7,7 @@ namespace Soloplan.WhatsON.GUI.Common.ConnectorTreeView
 {
   using System;
   using System.Collections.ObjectModel;
+  using System.Threading.Tasks;
   using System.Windows;
   using System.Windows.Controls;
   using System.Windows.Input;
@@ -174,9 +175,46 @@ namespace Soloplan.WhatsON.GUI.Common.ConnectorTreeView
           }
         }
 
+        if (changedConnector.CurrentStatus == null)
+        {
+          Task.Run(new Action(() => CheckForErrors(this.CurrentStatus,changedConnector)));
+        }
+
         this.Description = changedConnector.Description;
         this.CurrentStatus.Update(changedConnector.CurrentStatus);
       }));
+    }
+
+    public async Task CheckForErrors(BuildStatusViewModel build, Connector connector)
+    {
+      Status status = connector.CurrentStatus ?? new Status();
+
+      bool anyChanges = false;
+      if (connector.HasBuilds() == false)
+      {
+        anyChanges = true;
+        status.Details = "No builds yet";
+        status.State = ObservationState.Unknown;
+      }
+
+      if (await connector.CheckServerURL() == false)
+      {
+        anyChanges = true;
+        status.Details = "Project not available";
+        status.State = ObservationState.Unknown;
+      }
+      else if (await connector.CheckProjectURL() == false)
+      {
+        anyChanges = true;
+        status.Details = "Server not available";
+        status.State = ObservationState.Unknown;
+      }
+
+      if (anyChanges == true)
+      {
+        build.Update(status);
+      }
+      return;
     }
 
     /// <summary>

--- a/src/Soloplan.WhatsON.GUI.Common/ConnectorTreeView/StatusViewModel.cs
+++ b/src/Soloplan.WhatsON.GUI.Common/ConnectorTreeView/StatusViewModel.cs
@@ -39,6 +39,8 @@ namespace Soloplan.WhatsON.GUI.Common.ConnectorTreeView
 
     private string label;
 
+    private string errorMessage;
+
     public StatusViewModel(ConnectorViewModel connector)
     {
       this.Parent = connector;
@@ -180,6 +182,16 @@ namespace Soloplan.WhatsON.GUI.Common.ConnectorTreeView
       set
       {
         this.unstable = value;
+        this.OnPropertyChanged();
+      }
+    }
+
+    public string ErrorMessage
+    {
+      get => this.errorMessage;
+      set
+      {
+        this.errorMessage = value;
         this.OnPropertyChanged();
       }
     }

--- a/src/Soloplan.WhatsON.GUI.Common/Converters/StatusTotooltipVisibilityConverter.cs
+++ b/src/Soloplan.WhatsON.GUI.Common/Converters/StatusTotooltipVisibilityConverter.cs
@@ -7,37 +7,26 @@
 
 namespace Soloplan.WhatsON.GUI.Common.Converters
 {
-  using Soloplan.WhatsON.GUI.Common.ConnectorTreeView;
   using Soloplan.WhatsON.Model;
   using System;
   using System.Globalization;
   using System.Windows;
   using System.Windows.Data;
-  using System.Windows.Navigation;
 
   /// <summary>
-  /// Converter for projects DataTemplates. Determines visibility of a project tooltips. Uses StatusViewmodel method to find out if tooltip should be visible or not.
+  /// This converter is only for debug purposes to check what is going on in xaml.
   /// </summary>
-  public class MainStatusToVisibilityConverter : IValueConverter
+  public class StatusTotooltipVisibilityConverter : IValueConverter
   {
     public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
     {
-      if (value is StatusViewModel status)
-      {
-        return status.Parent.ShouldDisplayTooltip() ? Visibility.Visible : Visibility.Hidden;
-      }
-
-      if (value is ConnectorViewModel connector)
-      {
-        return connector.ShouldDisplayTooltip() ? Visibility.Visible : Visibility.Hidden;
-      }
-
-      return Visibility.Visible;
+      return ((ObservationState)value) != ObservationState.Unknown ? Visibility.Hidden : Visibility.Visible;
     }
 
     public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
     {
-      throw new NotImplementedException();
+      return value;
     }
+
   }
 }

--- a/src/Soloplan.WhatsON.GUI.Common/Converters/StatusTotooltipVisibilityConverter.cs
+++ b/src/Soloplan.WhatsON.GUI.Common/Converters/StatusTotooltipVisibilityConverter.cs
@@ -20,7 +20,7 @@ namespace Soloplan.WhatsON.GUI.Common.Converters
   {
     public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
     {
-      return ((ObservationState)value) != ObservationState.Unknown ? Visibility.Hidden : Visibility.Visible;
+      return ((ObservationState)value) != ObservationState.Unknown ? Visibility.Collapsed : Visibility.Visible;
     }
 
     public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)

--- a/src/Soloplan.WhatsON.GUI.Common/Soloplan.WhatsON.GUI.Common.csproj
+++ b/src/Soloplan.WhatsON.GUI.Common/Soloplan.WhatsON.GUI.Common.csproj
@@ -79,6 +79,7 @@
     <Compile Include="Converters\MainStatusToVisibilityConverter.cs" />
     <Compile Include="Converters\NullableBooleanConverter.cs" />
     <Compile Include="Converters\RGBAToRGBConverter.cs" />
+    <Compile Include="Converters\StatusTotooltipVisibilityConverter.cs" />
     <Compile Include="ExternalEnabledStateCommand.cs" />
     <Compile Include="Converters\InvertBooleanConverter.cs" />
     <Compile Include="Converters\InvertBooleanToVisibilityConverter.cs" />

--- a/src/Soloplan.WhatsON.Jenkins.GUI/JenkinsProjectDataTemplate.xaml
+++ b/src/Soloplan.WhatsON.Jenkins.GUI/JenkinsProjectDataTemplate.xaml
@@ -11,6 +11,7 @@
   <converters:NullOrDefaultToVisibilityConverter x:Key="NullOrDefaultVisibilityConverter" />
   <converters:InvertBooleanToVisibilityConverter x:Key="InvertBooleanToVisibilityConverter" />
   <converters:MainStatusToVisibilityConverter  x:Key="MainStatusToVisibilityConverter"/>
+  <converters:StatusTotooltipVisibilityConverter x:Key="StatusTotooltipVisibilityConverter"/>
 
   <Style x:Key="TextBlockTime" TargetType="{x:Type TextBlock}">
     <Setter Property="HorizontalAlignment" Value="Right" />
@@ -39,13 +40,14 @@
     </StackPanel>
   </ToolTip>
     
-  <ToolTip x:Key="RowTooltip" Visibility="{Binding CurrentStatus , Converter={StaticResource MainStatusToVisibilityConverter }}">
+  <ToolTip x:Key="RowTooltip" Visibility="{Binding Path=. , Converter={StaticResource MainStatusToVisibilityConverter }}">
     <StackPanel DataContext="{Binding CurrentStatus}">
       <buildServer:ProgressBarTooltipControl DataContext="{Binding}"/>
       <StackPanel Visibility="{Binding CulpritsAndLastCommittedDifferent, Converter={StaticResource BoolToVisibility}}">
         <buildServer:CulpritsControl Caption="Commits by:" CulpritsProp="{Binding DataContext.CommittedToThisBuild, RelativeSource={RelativeSource AncestorType=StackPanel}}" />
       </StackPanel>
       <buildServer:CulpritsControl Caption="All culprits for this build:" CulpritsProp="{Binding DataContext.Culprits, RelativeSource={RelativeSource AncestorType=StackPanel}}" />
+      <TextBlock Text="{Binding Details, Mode=OneWay}" Visibility="{Binding State , Converter={StaticResource StatusTotooltipVisibilityConverter}}"/>
     </StackPanel>
   </ToolTip>  
 

--- a/src/Soloplan.WhatsON.Jenkins.GUI/JenkinsProjectDataTemplate.xaml
+++ b/src/Soloplan.WhatsON.Jenkins.GUI/JenkinsProjectDataTemplate.xaml
@@ -38,6 +38,7 @@
         <buildServer:CulpritsControl Caption="Commits by:" CulpritsProp="{Binding DataContext.CommittedToThisBuild, RelativeSource={RelativeSource AncestorType=StackPanel}}" />
       </StackPanel>
       <buildServer:CulpritsControl Caption="All culprits for this build:" CulpritsProp="{Binding DataContext.Culprits, RelativeSource={RelativeSource AncestorType=StackPanel}}" />
+      <TextBlock Text="{Binding ErrorMessage, Mode=OneWay}" Visibility="{Binding State , Converter={StaticResource StatusTotooltipVisibilityConverter}}" />
     </StackPanel>
   </ToolTip>
     

--- a/src/Soloplan.WhatsON.Jenkins.GUI/JenkinsProjectDataTemplate.xaml
+++ b/src/Soloplan.WhatsON.Jenkins.GUI/JenkinsProjectDataTemplate.xaml
@@ -12,6 +12,7 @@
   <converters:InvertBooleanToVisibilityConverter x:Key="InvertBooleanToVisibilityConverter" />
   <converters:MainStatusToVisibilityConverter  x:Key="MainStatusToVisibilityConverter"/>
   <converters:StatusTotooltipVisibilityConverter x:Key="StatusTotooltipVisibilityConverter"/>
+  <converters:DebugConverter x:Key="DebugConverter"/>
 
   <Style x:Key="TextBlockTime" TargetType="{x:Type TextBlock}">
     <Setter Property="HorizontalAlignment" Value="Right" />
@@ -47,7 +48,7 @@
         <buildServer:CulpritsControl Caption="Commits by:" CulpritsProp="{Binding DataContext.CommittedToThisBuild, RelativeSource={RelativeSource AncestorType=StackPanel}}" />
       </StackPanel>
       <buildServer:CulpritsControl Caption="All culprits for this build:" CulpritsProp="{Binding DataContext.Culprits, RelativeSource={RelativeSource AncestorType=StackPanel}}" />
-      <TextBlock Text="{Binding Details, Mode=OneWay}" Visibility="{Binding State , Converter={StaticResource StatusTotooltipVisibilityConverter}}"/>
+      <TextBlock Text="{Binding ErrorMessage, Mode=OneWay}" Visibility="{Binding State , Converter={StaticResource StatusTotooltipVisibilityConverter}}" />
     </StackPanel>
   </ToolTip>  
 

--- a/src/Soloplan.WhatsON.Jenkins.GUI/JenkinsProjectViewModel.cs
+++ b/src/Soloplan.WhatsON.Jenkins.GUI/JenkinsProjectViewModel.cs
@@ -29,7 +29,7 @@ namespace Soloplan.WhatsON.Jenkins.GUI
     {
       if (this.CurrentStatus is JenkinsStatusViewModel status)
       {
-        return (status.Culprits.Count == 0 && status.CommittedToThisBuild.Count == 0 && status.State != ObservationState.Running) ? false : true;
+        return (status.Culprits.Count == 0 && status.CommittedToThisBuild.Count == 0 && status.State != ObservationState.Running && status.State != ObservationState.Unknown) ? false : true;
       }
 
       return true;

--- a/src/Soloplan.WhatsON.Jenkins.GUI/JenkinsProjectViewModel.cs
+++ b/src/Soloplan.WhatsON.Jenkins.GUI/JenkinsProjectViewModel.cs
@@ -7,6 +7,7 @@
 
 namespace Soloplan.WhatsON.Jenkins.GUI
 {
+  using Soloplan.WhatsON.Configuration;
   using Soloplan.WhatsON.GUI.Common.BuildServer;
   using Soloplan.WhatsON.GUI.Common.ConnectorTreeView;
   using Soloplan.WhatsON.Model;
@@ -32,6 +33,12 @@ namespace Soloplan.WhatsON.Jenkins.GUI
       }
 
       return true;
+    }
+
+    public override void ApplyConfiguration(ConnectorConfiguration configuration)
+    {
+      base.ApplyConfiguration(configuration);
+      this.Url = JenkinsApi.UrlHelper.ProjectUrl(this.Connector);
     }
 
     protected override BuildStatusViewModel GetStatusViewModel()

--- a/src/Soloplan.WhatsON.Jenkins/JenkinsConnector.cs
+++ b/src/Soloplan.WhatsON.Jenkins/JenkinsConnector.cs
@@ -57,6 +57,33 @@ namespace Soloplan.WhatsON.Jenkins
 
     private JenkinsStatus PreviousCheckStatus { get; set; }
 
+    /// <summary>
+    /// Checks correctness of self server URL.
+    /// </summary>
+    /// <returns>true when fine, false when url is broken.</returns>
+    public override async Task<bool> CheckServerURL()
+    {
+      return await this.IsReachableUrl(this.Address);
+    }
+
+    /// <summary>
+    /// Checks correctness of self project URL.
+    /// </summary>
+    /// <returns>true when fine, false when url is broken.</returns>
+    public override async Task<bool> CheckProjectURL()
+    {
+      return await this.IsReachableUrl(JenkinsApi.UrlHelper.ProjectUrl(this));
+    }
+
+    /// <summary>
+    /// Checks if there are any builds available.
+    /// </summary>
+    /// <returns>True when there are any builds, false when there are no builds.</returns>
+    public override bool HasBuilds()
+    {
+      return this.Snapshots.Count > 0 ? true : false;
+    }
+
     protected override async Task ExecuteQuery(CancellationToken cancellationToken)
     {
       await base.ExecuteQuery(cancellationToken);

--- a/src/Soloplan.WhatsON.Jenkins/JenkinsConnector.cs
+++ b/src/Soloplan.WhatsON.Jenkins/JenkinsConnector.cs
@@ -112,9 +112,37 @@ namespace Soloplan.WhatsON.Jenkins
     protected override async Task<Status> GetCurrentStatus(CancellationToken cancellationToken)
     {
       var job = await this.api.GetJenkinsJob(this, cancellationToken);
+      if (job == null)
+      {
+        if (await this.CheckServerURL() == false)
+        {
+          var status = new Status();
+          status.ErrorMessage = "Server not available";
+          status.InvalidBuild = true;
+          return status;
+        }
+        else if (await this.CheckProjectURL() == false)
+        {
+          var status = new Status();
+          status.ErrorMessage = "Project not available";
+          status.InvalidBuild = true;
+          return status;
+        }
+      }
+
+      if (job.LastBuild == null)
+      {
+        var status = new Status();
+        status.ErrorMessage = "No builds yet";
+        status.InvalidBuild = true;
+        return status;
+      }
+
       if (job?.LastBuild?.Number == null)
       {
-        return null;
+        var status = this.CreateStatus(job.LastBuild);
+        status.ErrorMessage = "No build number";
+        return status;
       }
 
       return this.CreateStatus(job.LastBuild);
@@ -175,6 +203,7 @@ namespace Soloplan.WhatsON.Jenkins
       newStatus.EstimatedDuration = new TimeSpan(latestBuild.EstimatedDuration * TicksInMillisecond);
       newStatus.Culprits = latestBuild.Culprits;
       newStatus.Url = JenkinsApi.UrlHelper.BuildUrl(this, newStatus.BuildNumber);
+      newStatus.ErrorMessage = latestBuild.Result;
 
       newStatus.CommittedToThisBuild = latestBuild.ChangeSets?.SelectMany(p => p.ChangeSetItems)
         .Select(p => p.Author)

--- a/src/Soloplan.WhatsON.Jenkins/JenkinsConnector.cs
+++ b/src/Soloplan.WhatsON.Jenkins/JenkinsConnector.cs
@@ -75,15 +75,6 @@ namespace Soloplan.WhatsON.Jenkins
       return await this.IsReachableUrl(JenkinsApi.UrlHelper.ProjectUrl(this));
     }
 
-    /// <summary>
-    /// Checks if there are any builds available.
-    /// </summary>
-    /// <returns>True when there are any builds, false when there are no builds.</returns>
-    public override bool HasBuilds()
-    {
-      return this.Snapshots.Count > 0 ? true : false;
-    }
-
     protected override async Task ExecuteQuery(CancellationToken cancellationToken)
     {
       await base.ExecuteQuery(cancellationToken);

--- a/src/Soloplan.WhatsON.Jenkins/Properties/ConfigurationItems.Designer.cs
+++ b/src/Soloplan.WhatsON.Jenkins/Properties/ConfigurationItems.Designer.cs
@@ -19,7 +19,7 @@ namespace Soloplan.WhatsON.Jenkins.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class ConfigurationItems {

--- a/src/Soloplan.WhatsON/Model/Connector.cs
+++ b/src/Soloplan.WhatsON/Model/Connector.cs
@@ -133,9 +133,7 @@ namespace Soloplan.WhatsON.Model
     {
       bool testStatus;
       WebRequest request = WebRequest.Create(urlInput);
-      request.Timeout = 10;
-
-      //WebResponse response;
+      request.Timeout = 50; //in ms.
       try
       {
         using (WebResponse response = await request.GetResponseAsync())
@@ -166,15 +164,6 @@ namespace Soloplan.WhatsON.Model
     /// </summary>
     /// <returns>true when fine, false when url is broken.</returns>
     public virtual async Task<bool> CheckProjectURL()
-    {
-      return false;
-    }
-
-    /// <summary>
-    /// Checks if there are any builds available.
-    /// </summary>
-    /// <returns>True when there are any builds, false when there are no builds.</returns>
-    public virtual bool HasBuilds()
     {
       return false;
     }

--- a/src/Soloplan.WhatsON/Model/Connector.cs
+++ b/src/Soloplan.WhatsON/Model/Connector.cs
@@ -7,9 +7,11 @@
 
 namespace Soloplan.WhatsON.Model
 {
-  using System.Collections.Generic;
+    using System;
+    using System.Collections.Generic;
   using System.Linq;
-  using System.Text;
+    using System.Net;
+    using System.Text;
   using System.Threading;
   using System.Threading.Tasks;
   using NLog;
@@ -125,6 +127,56 @@ namespace Soloplan.WhatsON.Model
 
       this.Snapshots.Add(new Snapshot(status));
       this.Snapshots.Sort((x, y) => x.Age.CompareTo(y.Age));
+    }
+
+    public virtual async Task<bool> IsReachableUrl(string urlInput)
+    {
+      bool testStatus;
+      WebRequest request = WebRequest.Create(urlInput);
+      request.Timeout = 10;
+
+      //WebResponse response;
+      try
+      {
+        using (WebResponse response = await request.GetResponseAsync())
+        {
+          testStatus = true;
+          response.Close();
+        }
+      }
+      catch (Exception)
+      {
+        testStatus = false;
+      }
+
+      return testStatus;
+    }
+
+    /// <summary>
+    /// Checks correctness of self server URL.
+    /// </summary>
+    /// <returns>true when fine, false when url is broken.</returns>
+    public virtual async Task<bool> CheckServerURL()
+    {
+      return false;
+    }
+
+    /// <summary>
+    /// Checks correctness of self project URL.
+    /// </summary>
+    /// <returns>true when fine, false when url is broken.</returns>
+    public virtual async Task<bool> CheckProjectURL()
+    {
+      return false;
+    }
+
+    /// <summary>
+    /// Checks if there are any builds available.
+    /// </summary>
+    /// <returns>True when there are any builds, false when there are no builds.</returns>
+    public virtual bool HasBuilds()
+    {
+      return false;
     }
 
     public override string ToString()

--- a/src/Soloplan.WhatsON/Model/Connector.cs
+++ b/src/Soloplan.WhatsON/Model/Connector.cs
@@ -226,7 +226,7 @@ namespace Soloplan.WhatsON.Model
     {
       log.Trace("Checking if snapshot should be taken...");
 
-      if (status != null && status.State != ObservationState.Running && this.Snapshots.All(x => x.Status.BuildNumber != status.BuildNumber))
+      if (status != null && status.State != ObservationState.Running && this.Snapshots.All(x => x.Status.BuildNumber != status.BuildNumber) && status.InvalidBuild == false)
       {
         log.Debug("Snapshot should be taken. {stat}", new { CurrentStatus = status });
         return true;

--- a/src/Soloplan.WhatsON/Model/Status.cs
+++ b/src/Soloplan.WhatsON/Model/Status.cs
@@ -35,8 +35,12 @@ namespace Soloplan.WhatsON.Model
 
     public virtual int BuildNumber { get; set; }
 
+    public virtual bool InvalidBuild { get; set; }
+
     public virtual bool Building { get; set; }
 
     public virtual string Url { get; set; }
+
+    public virtual string ErrorMessage { get; set; }
   }
 }

--- a/src/Soloplan.WhatsON/ObservationScheduler.cs
+++ b/src/Soloplan.WhatsON/ObservationScheduler.cs
@@ -138,6 +138,10 @@ namespace Soloplan.WhatsON
     /// <returns>Not used.</returns>
     private async Task StartObserveSingle(ObservationConnector connector, CancellationToken token)
     {
+      if (connector.Connector.Project.Contains("0.7.0"))
+      {
+        var x = 10;
+      }
       while (connector.Running)
       {
         try

--- a/src/Soloplan.WhatsON/ObservationScheduler.cs
+++ b/src/Soloplan.WhatsON/ObservationScheduler.cs
@@ -138,10 +138,6 @@ namespace Soloplan.WhatsON
     /// <returns>Not used.</returns>
     private async Task StartObserveSingle(ObservationConnector connector, CancellationToken token)
     {
-      if (connector.Connector.Project.Contains("0.7.0"))
-      {
-        var x = 10;
-      }
       while (connector.Running)
       {
         try


### PR DESCRIPTION
As mentioned in issue #7, whatson had a problem with jobs that it cant retrieve information about.  There are now 3+1 distinguished cases of an invalid project: 
Server is not available (the base address is invalid or server is down), 
Project not available (when the project address is incorrect),
No builds yet (when whatson did not recieve any builds in a project).
Error (when whatson recieved an error from the server, f. ex "aborted"). (Jenkins Only)

By accident this solves also the 'no icon' when a project is invalid bug.

There was a problem of urls not applying immediately after changing them in configuration window. That is now also fixed.
